### PR TITLE
Fix bug in species richness calculation

### DIFF
--- a/scripts/data_analysis.R
+++ b/scripts/data_analysis.R
@@ -1,6 +1,17 @@
 library(spatialEco)
 library(raster)
 
+# necessary variables
+load('./data/raster/species_richness.Rdata')
+load('./data/raster/temp_list.Rdata')
+load('./data/raster/chloro_list.Rdata')
+load('./data/raster/IUCN_richness_list.Rdata')
+load('./data/raster/salinity_list')
+load('./data/raster/mrd_raster_list.Rdata')
+load('./data/raster/pd_raster_list.Rdata')
+load('./data/raster/psv_raster_list.Rdata')
+load('./data/raster/psr_raster_list.Rdata')
+
 # linear regression temp vs richness
 pdf('./figures/temperature_vs_richness.pdf')
 for (i in 1:7) {
@@ -47,65 +58,45 @@ dev.off()
 
 # linear regression chlorophyll vs richness
 pdf('./figures/chlorophyll_vs_richness.pdf')
-richnessVchloro_list <- vector("list", length = 7)
-for (i in seq_along(c(1, 2, 3, 4, 5, 6, 7))) {
+for (i in 1:7) {
      plot(values(chloro_list[[i]]), values(species_richness_list[[i]]), 
           main = paste('resolution =', res(res_list[[i]])), 
           xlab = "Chlorophyll (mg/m3)", ylab = "Shark Richness")
      abline(lm(values(species_richness_list[[i]]) ~ values(chloro_list[[i]])), 
             col = 'red')
-     richnessVchloro <- lm(values(species_richness_list[[i]]) ~ 
-                           values(chloro_list[[i]]))
-     richnessVchloro_list[[i]] <- richnessVchloro
-     print(summary(richnessVchloro_list[[i]]))
 }
 dev.off()
 
 # linear regression normal vs threatened
 pdf('./figures/IUSN_vs_Normal.pdf')
-normalVthreatened_list <- vector("list", length = 7)
-for (i in seq_along(c(1, 2, 3, 4, 5, 6, 7))) {
+for (i in 1:7) {
      plot(values(species_richness_list[[i]]), values(IUCN_richness_list[[i]]), 
           main = paste('resolution =', res(res_list[[i]])), 
           xlab = "Normal Shark Richness", ylab = "Threatened Shark Richness")
      abline(lm(values(IUCN_richness_list[[i]]) ~ 
             values(species_richness_list[[i]])), col = 'red')
-     normalVthreatened <- lm(values(IUCN_richness_list[[i]]) ~ 
-                             values(species_richness_list[[i]]))
-     normalVthreatened_list[[i]] <- normalVthreatened
-     print(normalVthreatened_list[[i]])
 }
 dev.off()
 
 # latitude vs richness
 pdf('./figures/latitude_vs_richness.pdf')
-latVrichness_list <- vector("list", length = 7)
-for (i in seq_along(c(1, 2, 3, 4, 5, 6, 7))) {
+for (i in 1:7) {
      plot(abs(latitude_list[[i]]), values(species_richness_list[[i]]), 
           main = paste('resolution =', res(res_list[[i]])), xlab = "Latitude", 
           ylab = "Shark Richness")
      abline(lm(values(species_richness_list[[i]]) ~ abs(latitude_list[[i]])), 
             col = 'red')
-     latVrichness <- lm(values(species_richness_list[[i]]) ~ 
-                        abs(latitude_list[[i]]))
-     latVrichness_list[[i]] <- latVrichness
-     print(latVrichness_list[[i]])
 }
 dev.off()
 
 # salinity vs richness
 pdf('./figures/salinity_vs_richness.pdf')
-salinityVrichness_list <- vector("list", length = 7)
-for (i in seq_along(c(1, 2, 3, 4, 5, 6, 7))) {
+for (i in 1:7) {
      plot(values(salinity_list[[i]]), values(species_richness_list[[i]]), 
           main = paste('resolution =', res(res_list[[i]])), xlab = "Salinity", 
           ylab = "Shark Richness")
      abline(lm(values(species_richness_list[[i]]) ~ 
                  values(salinity_list[[i]])), col = 'red')
-     salinityVrichness <- lm(values(species_richness_list[[i]]) ~ 
-                               values(salinity_list[[i]]))
-     salinityVrichness_list[[i]] <- salinityVrichness
-     print(salinityVrichness_list[[i]])
 }
 dev.off()
 

--- a/scripts/rasterize_polygons.R
+++ b/scripts/rasterize_polygons.R
@@ -17,35 +17,32 @@ res(oceans_raster) <- 110
 save(oceans_raster, file = './data/raster/oceans_raster.Rdata')
 load('./data/raster/oceans_raster.Rdata')
 
-# for loop to change resolution of oceans_raster
-factor_val <- c(110, 220, 330, 440, 550, 770, 880, 1100)
-res_list <- vector("list", length = length(factor_val))
-res_list <- lapply(res_list, function(x) oceans_raster)
-for (i in seq_along(factor_val)) {
-     # making new resolutions
-     res(res_list[[i]]) <- factor_val[i]
-}
+# code to change resolution of rasters
+factor_val <- c(1, 2, 4, 8, 16, 32)
 
-# for loop to make a mask raster list
-mask_ras_list <- vector("list", length = length(res_list))
-for (i in seq_along(res_list)) {
-     mask_ras <- rasterize(oceans, res_list[[i]], field = 1)
-     mask_ras_list[[i]] <- mask_ras
-}
+# making continents polygon
+world <- map(database = "world", fill = T, plot = F)
+continents <- map2SpatialPolygons(world, IDs = world$names, proj4string = CRS("+proj=longlat"))
+continents <- spTransform(continents, CRS("+proj=cea +units=km"))
 
 # raster species polygons
 sp_files <- dir('./data/polygon')
 sp_raster <- vector("list", length = length(sp_files))
-for (i in seq_along(sp_files)) {
-      # read in 
-      temp_poly = readOGR(dsn = paste("./data/polygon/", sp_files[i], 
-                                      sep=''), layer = "OGRGeoJSON")
-      # convert projection to cea
-      temp_poly = spTransform(temp_poly, CRS("+proj=cea +units=km"))
-      # add field that will provide values when rasterized
-      temp_poly@data$occur = 1
-      # rasterize
-      sp_raster[[i]] = rasterize(temp_poly, res_list[[1]], field = 'occur')
+raster_res_list <- vector("list", length = length(factor_val))
+for (j in seq_along(factor_val)) {
+     for (i in seq_along(sp_files)) {
+          # read in 
+          temp_poly = readOGR(dsn = paste("./data/polygon/", sp_files[i], 
+                                          sep=''), layer = "OGRGeoJSON")
+          # convert projection to cea
+          temp_poly = spTransform(temp_poly, CRS("+proj=cea +units=km"))
+          # add field that will provide values when rasterized
+          temp_poly@data$occur = 1
+          # rasterize
+          sp_raster[[i]] = rasterize(temp_poly, oceans_raster, field = 'occur')
+     }
+  raster_res_list[[j]] = sp_raster
+  raster_res_list[[j]] = aggregate(sp_raster[[i]], fac = j, fun = sum) > 0
 }
 
 # now aggregate this finest spatial grid to the coarser resolutions
@@ -62,14 +59,13 @@ save(raster_res_list, file = './data/raster/raster_res_list.Rdata')
 load('./data/raster/raster_res_list.Rdata')
 
 # creating a species richness layer for each resolution
-pdf('./figures/species_richness_maps.pdf')
+pdf('./figures/species_richness_maps_unmasked.pdf')
 species_richness_list <- vector("list", length = length(raster_res_list))
 for (i in seq_along(raster_res_list)) {
      sp_raster_stack <- stack(raster_res_list[[i]])
      species_richness <- calc(sp_raster_stack, fun = sum, na.rm = T)
-     species_richness <- mask(species_richness, mask_ras_list[[i]])
      plot(species_richness, main=paste('resolution =', res(res_list[[i]])))
-     plot(oceans, add = T)
+     plot(continents, add = T, col = "black")
      species_richness_list[[i]] <- species_richness
 }
 dev.off()
@@ -92,13 +88,13 @@ coordinates(temp) <- ~LONGITUDE + LATITUDE
 class(temp)
 proj4string(temp) <- "+proj=longlat +datum=WGS84"
 temp <- spTransform(temp, CRS("+proj=cea +units=km"))
-pdf('./figures/temperature.pdf')
-temp_list <- vector("list", length = length(res_list))
-for (i in seq_along(res_list)) {
-     temp_raster <- rasterize(temp, res_list[[i]], 'Meandepth')
-     temp_raster <- mask(temp_raster, mask_ras_list[[i]])
+pdf('./figures/temperature_unmasked.pdf')
+temp_list <- vector("list", length = length(factor_val))
+for (i in seq_along(factor_val)) {
+     temp_raster <- rasterize(temp, oceans_raster, 'Meandepth')
+     temp_raster = aggregate(temp_raster, fac = i, fun = sum) > 0
      plot(temp_raster, main = paste('resolution =', res(res_list[[i]])))
-     plot(oceans, add = T)
+     plot(continents, add = T, col = "black")
      temp_list[[i]] <- temp_raster
 }
 dev.off()
@@ -111,13 +107,14 @@ chloro <- raster('./data/Environment/MY1DMM_CHLORA_2017-06-01_rgb_360x180.TIFF')
 chloro <- rasterToPolygons(chloro)
 chloro <- spTransform(chloro, CRS("+proj=cea +units=km"))
 pdf('./figures/chlorophyll.pdf')
-chloro_list <- vector("list", length = length(res_list))
-for (i in seq_along(res_list)) {
-     chloro_ras <- rasterize(chloro, res_list[[i]], 
+chloro_list <- vector("list", length = length(factor_val))
+for (i in seq_along(factor_val)) {
+     chloro_ras <- rasterize(chloro, oceans_raster, 
                              'MY1DMM_CHLORA_2017.06.01_rgb_360x180')
+     chloro_ras <- aggregate(chloro_ras, fac = i, fun = sum) > 0
      values(chloro_ras)[values(chloro_ras) == 255] <- NA
      plot(chloro_ras, main = paste('resolution =', res(res_list[[i]])))
-     plot(oceans, add = T)
+     plot(continents, add = T, col = "black")
      chloro_list[[i]] <- chloro_ras
 }
 dev.off()
@@ -128,8 +125,8 @@ load('./data/raster/chloro_list.Rdata')
 # IUCN shark species richness
 sp_files_IUCN <- dir('./data/IUCN')
 IUCN_raster <- vector("list", length = length(sp_files_IUCN))
-IUCN_res_list <- vector("list", length = length(res_list))
-for (j in seq_along(res_list)) {
+IUCN_res_list <- vector("list", length = length(factor_val))
+for (j in seq_along(factor_val)) {
   for (i in seq_along(sp_files_IUCN)) {
     # read in 
     temp_poly = readOGR(dsn = paste("./data/polygon/", sp_files_IUCN[i], 
@@ -139,23 +136,23 @@ for (j in seq_along(res_list)) {
     # add field that will provide values when rasterized
     temp_poly@data$occur = 1
     # rasterize
-    IUCN_raster[[i]] = rasterize(temp_poly, res_list[[j]], field = 'occur')
+    IUCN_raster[[i]] = rasterize(temp_poly, oceans_raster, field = 'occur')
   }
   IUCN_res_list[[j]] = IUCN_raster
+  IUCN_res_list[[j]] = aggregate(IUCN_raster[[i]], fac= j, fun = sum) > 0
 }
 
 save(IUCN_res_list, file = './data/raster/IUCN_res_list.Rdata')
 load('./data/raster/IUCN_res_list.Rdata')
 
 # creating an IUCN richness layer for each resolution
-pdf('./figures/IUCN_richness_maps.pdf')
+pdf('./figures/IUCN_richness_maps_unmasked.pdf')
 IUCN_richness_list <- vector("list", length = length(IUCN_res_list))
 for (i in seq_along(IUCN_res_list)) {
      sp_raster_stack <- stack(IUCN_res_list[[i]])
      IUCN_richness <- calc(sp_raster_stack, fun = sum, na.rm = T)
-     IUCN_richness <- mask(IUCN_richness, mask_ras_list[[i]])
      plot(IUCN_richness, main = paste('resolution =', res(res_list[[i]])))
-     plot(oceans, add = T)
+     plot(continents, add = T, col = "black")
      IUCN_richness_list[[i]] <- IUCN_richness
 }
 dev.off()
@@ -178,28 +175,29 @@ salinity$Meandepth <- rowMeans(salinity[,3:86], na.rm = TRUE)
 coordinates(salinity) <- ~ Longitude + Latitude
 proj4string(salinity) <- "+proj=longlat +datum=WGS84"
 salinity <- spTransform(salinity, CRS("+proj=cea +units=km"))
-pdf('./figures/salinity.pdf')
-salinity_list <- vector("list", length = length(res_list))
-for (i in seq_along(res_list)) {
-     salinity_raster <- rasterize(salinity, res_list[[i]], 'Meandepth')
-     salinity_raster <- mask(salinity_raster, mask_ras_list[[i]])
+pdf('./figures/salinity_unmasked.pdf')
+salinity_list <- vector("list", length = length(factor_val))
+for (i in seq_along(factor_val)) {
+     salinity_raster <- rasterize(salinity, oceans_raster, 'Meandepth')
+     salinity_raster <- aggregate(salinity_raster, fac = i, fun = sum) > 0
      plot(salinity_raster, main = paste('resolution =', res(res_list[[i]])))
-     plot(oceans, add = T)
+     plot(continents, add = T, col = "black")
      salinity_list[[i]] <- salinity_raster
 }
 dev.off()
 
 save(salinity_list, file = './data/raster/salinity_list')
+load('./data/raster/salinity_list')
 
 # distance from coast
 coast_distance_list <- vector("list", length = length(res_list))
-pdf('./figures/distance_from_coast.pdf')
+pdf('./figures/distance_from_coast_unmasked.pdf')
 for (i in seq_along(res_list)) {
   distance_raster <- setValues(res_list[[i]], 0)
-  distance_raster <- mask(distance_raster, mask_ras_list[[i]], inverse = T)
+  distance_raster <- mask(distance_raster, mask_ras_list, inverse = T)
   rd <- distance(distance_raster)
   plot(rd, main = paste('resolution =', res(res_list[[i]])))
-  plot(oceans, add = T)
+  plot(continents, add = T, col = "black")
   coast_distance_list[[i]] <- rd
 }
 dev.off()


### PR DESCRIPTION
A bug occurred in our code because @EmmalineSheahan was using the function raster::rasterize for each spatial grain independently to convert the species polygons into rasters. This function only marks a raster as containing a species if they polygon overlaps the centroid of the cell. This PR starts the process of solving this bug by only rasterizing the polygons at a relatively fine grain and then using the function aggregate to scale the data up to larger grains.

This PR is identical to #21 except this has a patch for repo conflict. 